### PR TITLE
Split 'About' -> 'About & Design'

### DIFF
--- a/assets/css/layout.css
+++ b/assets/css/layout.css
@@ -73,6 +73,14 @@ p {
 	margin: 1.25rem;
 }
 
+a {
+  color: var(--forest);
+}
+
+a:visited {
+  color: #98a9a9;
+}
+
 /*Utility*/
 .lifter {
 	padding: 0 1rem;
@@ -116,10 +124,12 @@ p {
 	padding-top: 0;
 	display: flex;
 	place-content: center;
+  letter-spacing: .16rem;
 }
 
 a.logo {
   text-decoration: none;
+  color: var(--bright-silver);
 }
 
 .error a.logo {
@@ -132,6 +142,8 @@ header,
 footer {
   background: var(--forest);
 	color: var(--bright-silver);
+  /*Set z so system-map doesn't overlap*/
+  z-index: 1;
 }
 
 header.error,
@@ -192,6 +204,10 @@ header .top-nav {
 	justify-content: center;
 	position: sticky;
 	top: 0;
+}
+
+.main-nav a {
+  color: var(--bright-silver);
 }
 
 /*Home*/
@@ -374,15 +390,15 @@ body>.main-nav ul {
   color: #ffffff;
 }
 
-/*About*/
-.about-alignment-wrapper {
+/*Article*/
+.article-alignment-wrapper {
 	width: 100%;
 	display: flex;
 	flex-direction: column;
 	align-items: center;
 }
 
-.about-header {
+.article-header {
   background-color: #98a9a9;
 	color: var(--bright-silver);
 	text-align: start;
@@ -392,6 +408,7 @@ body>.main-nav ul {
   margin: 0 calc(-1 * var(--gutter));
 
   /*Layout*/
+  align-self: stretch;
 	display: flex;
 	flex-direction: column;
 
@@ -399,19 +416,19 @@ body>.main-nav ul {
 	padding: 2rem 20%;
 }
 
-.about-header .hr-title {
+.article-header .hr-title {
 	align-self: flex-end;
 	color: var(--bright-silver);
 	font-weight: normal;
 }
 
-.about-header-hr {
+.article-header-hr {
 	border: none;
 	border-top: 1px solid silver;
 	margin: 1rem 0;
 }
 
-.about-header h1 {
+.article-header h1 {
   display: inline;
 	font-weight: 400;
 
@@ -419,7 +436,7 @@ body>.main-nav ul {
 	font-size: 3rem;
 }
 
-.about-header h2 {
+.article-header h2 {
   color: var(--bright-silver);
   color: var(--darkness);
 	padding: 1rem 0;
@@ -427,24 +444,20 @@ body>.main-nav ul {
   line-height: 1.5;
 }
 
-.about-header .engineer {
-  white-space: nowrap;
-}
-
 /*Nowrap "System Administrator" in About Me Title*/
 @media (max-width: 400px) {
-  .about-header .rhcsys-admin {
+  .article-header .rhcsys-admin {
     white-space: nowrap;
   }
 }
 @media (min-width: 700px) and (max-width: 800px) {
-  .about-header .rhcsys-admin {
+  .article-header .rhcsys-admin {
     white-space: nowrap;
   }
 }
 /*-----------------------------------------------*/
 
-.about-container {
+.article-container {
   /*Box*/
 	width: auto;
 	padding: 2rem 20%;
@@ -455,23 +468,53 @@ body>.main-nav ul {
 	place-content: flex-start;
 }
 
-.about-container h2,
-.about-container h3 {
+.article-container h2,
+.article-container h3 {
 	color: var(--darkness);
 }
 
-.about-container p {
+.article-container p {
 	margin-left: 0;
 	font-size: 18px;
 	line-height: 28px;
 	color: rgb(68, 64, 62);
 }
 
-.about-container blockquote {
+.article-container blockquote {
 	width: var(--group-width);
 	padding: 0 2rem;
 	border-left: solid rgb(120, 115, 115);
 	line-height: 28px;
+}
+
+/*About*/
+.article-header .engineer {
+  white-space: nowrap;
+}
+
+/*Design*/
+.design .article-container p:first-child {
+  font-weight: 700;
+}
+
+.design ul {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  margin-left: 1rem;
+}
+
+.design li {
+  display: flex;
+  flex-direction: column;
+}
+
+.design li:first-child {
+  margin-top: 1rem;
+}
+
+.design li p {
+  margin: 0;
 }
 
 /* No Mobile Support Page */
@@ -1105,16 +1148,16 @@ footer p {
   }
 
 /*About*/
-  .about-header,
-  .about-container {
+  .article-header,
+  .article-container {
     padding: 1rem 8%;
   }
 
-  .about-header h1 {
+  .article-header h1 {
     font-size: 2rem;
   }
 
-  .about-header h2 {
+  .article-header h2 {
     font-size: 1rem;
   }
 }

--- a/assets/templates/_article.html
+++ b/assets/templates/_article.html
@@ -1,0 +1,17 @@
+{{template "article" .}}{{define "article"}}
+<div class="content {{template "article-class" .}}" >
+		<div class="article-alignment-wrapper" >
+			<div class="article-header">
+        <h3 class="hr-title" >
+          [&lt;{{template "hr-title" .}}&gt;]
+        </h3>
+				<hr class="article-header-hr" >
+        {{template "article-title" .}}
+        {{template "article-desc" .}}
+			</div>
+			<div class="article-container" >
+        {{template "article-content" .}}
+			</div>
+		</div>
+	</div>
+{{end}}

--- a/assets/templates/content/about.html
+++ b/assets/templates/content/about.html
@@ -1,62 +1,44 @@
+{{define "article-class"}}
+about
+{{end}}
+
+{{define "hr-title"}}
+About Me
+{{end}}
+
+{{define "article-title"}}
+  <div class="fullstack">
+    <h1>
+      Fullstack Software 
+    </h1>
+    <h1 class="engineer">
+      Engineer, and
+    </h1>
+  </div>
+  <div class="rhcsa">
+    <h1>
+      RedHat Certified 
+    </h1>
+    <h1 class="rhcsys-admin">
+      System Administrator
+    </h1>
+  </div>
+{{end}}
+
+{{define "article-desc"}}
+  <h2>
+    Focused primarily on tools, services, and systems operating in and around container contexts within Linux environments, coming from a background in web development
+  </h2>
+{{end}}
+
+{{define "article-content"}}
+				<p>
+				With the ever-growing stacks that software live on, and the lines of responsibility between developer/operations/infrastructure bluring daily, "Full Stack" means different things in different contexts and has become a somewhat ambiguous term.
+        <br>So when I say "full stack", I simply mean I am comfortable enough within a range of responsibilities to jump in and be useful, i.e. from system administration, infrastructure, devops, orchestration, to backend server implementations and business logic all the way to frontend web frameworks and design.
+        <br>I created the <a href="/system">System</a> application to more tangibly give a wholistic impression of where I can work, and with which technologies I created the system that floats this website. 
+				</p>
+{{end}}
+
 {{define "content"}}
-	<div class="content" >
-		<div class="about-alignment-wrapper" >
-			<div class="about-header">
-        <h3 class="hr-title" >[&lt;About Me&gt;]</h3>
-				<hr class="about-header-hr" >
-        <div class="fullstack">
-          <h1>
-            Fullstack Software 
-          </h1>
-          <h1 class="engineer">
-            Engineer, and
-          </h1>
-        </div>
-        <div class="rhcsa">
-          <h1>
-            RedHat Certified 
-          </h1>
-          <h1 class="rhcsys-admin">
-            System Administrator
-          </h1>
-        </div>
-				<h2>
-					Focused primarily on tools, services, and systems operating in and around container contexts within Linux environments, coming from a background in web development
-				</h2>
-			</div>
-			<div class="about-container" >
-				<!-- <p>
-					As a developer, I believe in innovation after convention, that is, cleverness is costly unless necessary and convention is built on the success of an ecosystem. As an engineer, I believe in creating tools which solve the problems created by technology that has outlived it's scope of innovation. Knowing when to wear which hat is one of the many keys to building successful software.
-				</p> -->
-				<p>
-				"Full Stack" is sort of an ambiguous term, and some believe it doesn't really exist, which in a sense I agree with, but with ever growing stack that software lives on, and the lines between responsibility bluring daily there aren't always enough terms to quickly and accurately categorize ourselves. So when I say "full stack" for myself, I do not imply that I am a specialist in every technology implemented in every level of the environment, that would be ridiculous, I simply mean I am comfortable enough within a range of responsibilities to jump in and be useful. I created the <a href="/system">System</a> application to more tangibly give a wholistic impression of where I can work, and with what technologies I have used to create the system that floats this website. 
-				</p>
-				<p>
-					When designing systems or software there are many considerations to weigh, and for me this process is the longest and toughest, but when I am developing I try to keep these principles at the forefront of my programming process. 
-				</p>
-				<h2>Modularity</h2>
-				<p>
-					This is arguably a design category but I try to remember these for my code as well, it helps guide my implementation.
-					You never know what is on the horizon for a project, and you never know what will become of the technology you are using, whether it be new product requirements that call for a more suitable framework, or the organization that maintains a piece of your stack changes its terms of service or discontinues their product altogether, good software is built on reusable, blind components flexible enough to plug-and-play different implementation detail. This approach keeps development and transitions sane and downtime to a minimum when surprises come, which they inevitably will.
-				</p>
-				<h2>Maintainability</h2>
-				<h3>Readability</h3>
-				<p>
-					The developer is the only necessary resource for software. This is obviously hyperbole, but the principle holds; write code to be read, not executed. Small changes and quick iteration is the way forward, code should be read like a book, it should tell a story at a glance, and if the developer has to go to a different library to checkout a different book just to get to the next page the development process with stutter. Definitions should be as much as possible, layed out in order of use; <code>main</code> (or equivalent) should be at the top of the page, and the first function it uses should be defined directly below, in this fashion the story will unfold organically.
-				</p>
-				<h3>Simplicity</h3>
-				<p>
-					There is a difference between simplicity of syntax and simplicity of logic. If a developer has a hard time following the logic of a program, its too complex, if a developer has a hard time reading a line of code, they need to go to the docs. There is of course a balance here, we've all seen some comically convoluted oneliners that are absolutely unreadable, but that has more to do with the readabilit of a program, when I refer to simplicity I mean that of logic. I like the advice of the <a href="https://golang.org/ref/mem#tmp_1" >Golang Memory Model</a> 
-					<blockquote>
-						"... If you must read the rest of this document to understand the behavior of your program, you are being too clever.
-						Don't be clever."
-					</blockquote>
-				</p>
-				<h2>Cost/Context</h2>
-				<p>
-					Every decision has a price, namely time, and unfortunately "better" doesn't always make the cut.
-				</p>
-			</div>
-		</div>
-	</div>
+{{template "article" .}}
 {{end}}

--- a/assets/templates/content/design.html
+++ b/assets/templates/content/design.html
@@ -1,0 +1,136 @@
+{{define "article-class"}}
+design
+{{end}}
+
+{{define "hr-title"}}
+Design
+{{end}}
+
+{{define "article-title"}}
+<h1>
+Thoughts on Software Design
+</h1>
+{{end}}
+
+{{define "article-desc"}}
+  <h2>
+    Context is everything
+  </h2>
+{{end}}
+
+{{define "article-content"}}
+        <p>
+        When designing systems or software there are many considerations to weigh, and more often than not you have to start building before you know most of them. 
+        <br>Regardless, I try to keep these ideas floating around my mind while programming 
+        </p>
+				<p>
+        As a <i>developer</i>, I believe in innovation after convention, that is, cleverness is costly unless necessary and convention is built on the success of an ecosystem.<br>
+        <br>As an <i>engineer</i>, I believe in creating tools that solve problems created by conventions that have outlived their scope of innovation in an ever-growing ecosystem.<br>
+          <br>Knowing when to wear which hat is one of the many keys to building successful software.
+				</p>
+				<h2>Maintainability</h2>
+        <p>
+        It's really all just about maintainability, this is the highest cost of code, but means very different things depending on the team, environment, stack, timeline, etc.
+        <br>
+        These are general, language agnostic ideas that are once again, highly depend on the context.
+        </p>
+				<h3>Readability</h3>
+				<p>
+					The developer is the only necessary resource for software. This is obviously hyperbole, but the principle holds; write code to be read, not executed.
+          <br>
+          Small changes and quick iteration is the way forward, and to that effect code should be read like a book, it should tell a story at a glance, and, to extend the metaphor, if the developer has to go to a different library to checkout a different book just to get to the next page the development process will stutter. Definitions should be as much as possible, layed out in order of use; <code>main</code> (or equivalent) should be at the top of the page, and the first function it uses should be defined directly below, in this fashion the story will unfold organically.
+				</p>
+					<blockquote>
+						"The idea is that another programmer (including your future self) can glance down a single column and understand the expected flow of the code."
+            <br>
+            <a href="https://medium.com/@matryer/line-of-sight-in-code-186dd7cdea88" target="_blank" rel="noopener noreferrer">
+              <i>- Mat Ryer</i>
+            </a>
+
+					</blockquote>
+				<p>
+          It's not about increasing the developer's cognitive capactity, it's about removing cognitive load from inappropriate sources; it's the same reason you shouldn't text and drive, it's not that you aren't capable of doing it, you're just worse at it when you do.
+				</p>
+				<h3>Simplicity</h3>
+				<p>
+					There is a difference between simplicity of syntax and simplicity of logic. If a developer has a hard time following the logic of a program, its too complex, if a developer has a hard time reading a line of code, they need to go to the docs. There is of course a balance here, we've all seen some comically convoluted oneliners that are absolutely unreadable, but that has more to do with the readability of a program, when I refer to simplicity I mean that of logic. I like the advice of the <a href="https://golang.org/ref/mem#tmp_1" >Golang Memory Model</a> 
+					<blockquote>
+						"... If you must read the rest of this document to understand the behavior of your program, you are being too clever.
+            <br>
+						Don't be clever."
+					</blockquote>
+				</p>
+				<h3>Modularity</h3>
+				<p>
+				You never know what is on the horizon for a project, and you never know what will become of the technology you are using, whether it be new product requirements that call for a more suitable framework, or the organization that maintains a piece of your stack changes its terms of service or even discontinues their product altogether, good software is built on reusable, blind components flexible enough to swap implementation detail without rewriting your entire codebase. This approach keeps development and transitions sane and downtime to a minimum when surprises come, which they inevitably will.
+				</p>
+        <p>
+        However, this is all in a perfect world where everything is as simple as it sounds, which it's not, and it isn't. I think the idea that your database or framework <i>isn't</i> a part of your business logic is a bit naive. No matter how perfectly abstracted your code, changing the stack you've built on for years is <i>never</i> going to be a simple plug-and-play. There is only every unexpected everything.
+        </p>
+        <p>
+        I think the core of the idea of modular/abstracted code is really trying to get at easier testing, simpler refactoring, and quicker additions/removals. Good abstraction is about fewer abstractions and well designed contracts.
+        </p>
+        <h2>Excellent Articles & Talks on Software Design</h2>
+        <ul>
+          <li>
+            <h4>Kat Zien</h4>
+            <p>
+            <a href="https://www.youtube.com/watch?v=oL6JBUk6tj0" target="_blank" rel="noopener noreferrer">
+              How Do You Structure Your Go Apps
+            </a>
+            </p>
+          </li>
+          <li>
+            <h4>Mat Ryer</h4>
+            <p>
+            <a href="https://pace.dev/blog/2018/05/09/how-I-write-http-services-after-eight-years.html" target="_blank" rel="noopener noreferrer">
+              How I Write HTTP Services After 8 Years
+            </a>
+            </p>
+          </li>
+          <li>
+            <h4>Peter Bourgon</h4>
+            <p>
+            <a href="https://www.youtube.com/watch?v=NX0sHF8ZZgw" target="_blank" rel="noopener noreferrer">
+              Go + Microservice = Go Kit
+            </a>
+            </p>
+          </li>
+          <li>
+            <h4>Ben Johnson</h4>
+            <p>
+            <a href="https://www.gobeyond.dev/standard-package-layout/" target="_blank" rel="noopener noreferrer">
+              Standard Package Layout
+            </a>
+            <a href="https://www.gobeyond.dev/packages-as-layers/" target="_blank" rel="noopener noreferrer">
+              Packages as Layers
+            </a>
+            <a href="https://www.gobeyond.dev/wtf-dial" target="_blank" rel="noopener noreferrer">
+              WTF Dial
+            </a>
+            </p>
+          </li>
+          <li>
+            <h4>Bill Kennedy</h4>
+            <p>
+            Not really just on design, but all his articles on Ardan Labs'
+            <a href="https://www.ardanlabs.com/all-posts" target="_blank" rel="noopener noreferrer">
+              Blog
+            </a>
+            are excellent
+            </p>
+          </li>
+          <li>
+            <h4>Dave Cheney</h4>
+            <p>
+            <a href="https://dave.cheney.net/2016/08/20/solid-go-design" target="_blank" rel="noopener noreferrer">
+              SOLID Go Design
+            </a>
+            </p>
+          </li>
+        </ul>
+{{end}}
+{{define "content"}}
+{{template "article" .}}
+
+{{end}}

--- a/assets/templates/content/home.html
+++ b/assets/templates/content/home.html
@@ -163,12 +163,12 @@
 				</a>
 			</article>
 			<article class="card home-projects" >
-				<a class="lifter" href="/" >
+				<a class="lifter" href="/design" >
 					<h5 class="title" >
-						Projects
+						Design
 					</h5>
 					<p>
-						Other projects I've been working on
+						Stuff I think about when I think about software design
 					</p>
 				</a>
 			</article>

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -21,6 +21,7 @@ func (r *Router) NewRouter() {
 	router.GET("/", r.HandleHome)
 	router.GET("/about", r.HandleAbout)
 	router.GET("/system", r.HandleSystem)
+	router.GET("/design", r.HandleDesign)
 	router.ServeFiles("/client/*filepath", http.Dir("client"))
 	router.ServeFiles("/css/*filepath", http.Dir("assets/css"))
 	router.ServeFiles("/assets/*filepath", http.Dir("assets"))
@@ -42,6 +43,14 @@ func (rtr Router) HandleAbout(w http.ResponseWriter, r *http.Request, _ httprout
 	home.Title = "About"
 
 	home.Template.Execute(w, home)
+}
+
+func (rtr Router) HandleDesign(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	var design template.View
+	design.Template = rtr.Templates["design.html"]
+	design.Title = "Design"
+
+	design.Template.Execute(w, design)
 }
 
 func (rtr Router) HandleSystem(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -22,7 +22,7 @@ func populateTemplates() map[string]*template.Template {
 	const basePath = "assets/templates"
 	tmplMap := make(map[string]*template.Template)
 	layout := template.Must(template.ParseFiles(basePath + "/_layout.html"))
-	template.Must(layout.ParseFiles(basePath + "/_header.html", basePath + "/_footer.html", basePath + "/_error_footer.html", basePath + "/_error_header.html"))
+	template.Must(layout.ParseFiles(basePath + "/_header.html", basePath + "/_footer.html", basePath + "/_error_footer.html", basePath + "/_error_header.html", basePath + "/_article.html"))
 	contentPath := filepath.Join(basePath + "/content")
 	log.Println(contentPath)
 	dir, err := os.ReadDir(contentPath)


### PR DESCRIPTION
Replaced 'Projects' card with 'Design' after splitting 'About Me' into a
more brief about page and a page dedicated to my thoughts on high level
software design.
Templatized 'Articles' to reduce overhead of creating new pages for the
site. 'Articles' consist of a header with a title and an article
description, and a content portion.